### PR TITLE
Singleton paterni C# örneği için lock objesi yerel değişkenden aynı sınıfın statik üyesi olacak şekilde değiştirildi.

### DIFF
--- a/singleton/c-sharp/Database.cs
+++ b/singleton/c-sharp/Database.cs
@@ -16,16 +16,17 @@ namespace Singleton
 
         public static Database GetInstance()
         {
-            lock (lockObject)
+            if (database == null)
             {
-                if (database == null)
+                lock (lockObject)
                 {
-                    database = new Database();
+                    if (database == null)
+                    {
+                        database = new Database();
+                    }
                 }
-
-                return database;
             }
-
+            return database;
         }
     }
 }

--- a/singleton/c-sharp/Database.cs
+++ b/singleton/c-sharp/Database.cs
@@ -6,6 +6,7 @@ namespace Singleton
 {
     public class Database
     {
+        private static object lockObject = new Object();
         private static Database database;
 
         private Database()
@@ -15,20 +16,16 @@ namespace Singleton
 
         public static Database GetInstance()
         {
-            if (database == null)
+            lock (lockObject)
             {
-                var lockObject = new object();
-
-                lock (lockObject)
+                if (database == null)
                 {
-                    if (database == null)
-                    {
-                        database = new Database();
-                    }
+                    database = new Database();
                 }
+
+                return database;
             }
 
-            return database;
         }
     }
 }


### PR DESCRIPTION
Singleton paterni C# örneği için lock objesi yerel değişkenden aynı sınıfın statik üyesi olacak şekilde değiştirildi.